### PR TITLE
Add minimal React Vite frontend

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,26 @@
+# AI Opportunities Web App
+
+This is a minimalist React application built with Vite **4.1.0** and TypeScript. The UI uses Bootstrap for styling. It aims to provide a skeleton implementation of a platform where organizations can post AI opportunities and community members can interact with them.
+
+## Features
+
+- **Registration and Login** pages with email and phone fields
+- **Dashboard** with a search bar for opportunities
+- **Create Opportunity** page (organizations only)
+- **Community** page placeholder
+- Basic navigation using React Router
+
+## Development
+
+Node modules are not included in this repository. To run or build the project locally, ensure that you have Node.js installed and run:
+
+```bash
+npm install
+npm run dev
+```
+
+This will start Vite on port 3000.
+
+## Disclaimer
+
+The current implementation is a front‑end prototype only. It lacks backend integration for features such as email/phone verification, data persistence, or authentication. These would need to be implemented separately.

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Opportunities</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ai-opportunities",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.4.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "typescript": "^5.3.2",
+    "vite": "4.1.0"
+  }
+}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,0 +1,43 @@
+import { Routes, Route, Link } from 'react-router-dom';
+import LoginPage from './pages/LoginPage';
+import RegisterPage from './pages/RegisterPage';
+import Dashboard from './pages/Dashboard';
+import CreateOpportunity from './pages/CreateOpportunity';
+import Community from './pages/Community';
+
+function App() {
+  return (
+    <div>
+      <nav className="navbar navbar-expand navbar-light bg-light px-3">
+        <Link className="navbar-brand" to="/">AI Opportunities</Link>
+        <ul className="navbar-nav ms-auto">
+          <li className="nav-item">
+            <Link className="nav-link" to="/login">Login</Link>
+          </li>
+          <li className="nav-item">
+            <Link className="nav-link" to="/register">Register</Link>
+          </li>
+          <li className="nav-item">
+            <Link className="nav-link" to="/dashboard">Dashboard</Link>
+          </li>
+          <li className="nav-item">
+            <Link className="nav-link" to="/create">Create</Link>
+          </li>
+          <li className="nav-item">
+            <Link className="nav-link" to="/community">Community</Link>
+          </li>
+        </ul>
+      </nav>
+      <Routes>
+        <Route path="/" element={<LoginPage />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/create" element={<CreateOpportunity />} />
+        <Route path="/community" element={<Community />} />
+      </Routes>
+    </div>
+  );
+}
+
+export default App;

--- a/app/src/components/SearchBar.tsx
+++ b/app/src/components/SearchBar.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+function SearchBar() {
+  const [query, setQuery] = useState('');
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    alert(`Search for ${query}`);
+  };
+
+  return (
+    <form className="d-flex" onSubmit={handleSearch}>
+      <input
+        className="form-control me-2"
+        type="search"
+        placeholder="Search opportunities or organizations"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <button className="btn btn-outline-success" type="submit">
+        Search
+      </button>
+    </form>
+  );
+}
+
+export default SearchBar;

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import 'bootstrap/dist/css/bootstrap.min.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/app/src/pages/Community.tsx
+++ b/app/src/pages/Community.tsx
@@ -1,0 +1,10 @@
+function Community() {
+  return (
+    <div className="container mt-5">
+      <h2>Community</h2>
+      <p>Members and groups will be listed here.</p>
+    </div>
+  );
+}
+
+export default Community;

--- a/app/src/pages/CreateOpportunity.tsx
+++ b/app/src/pages/CreateOpportunity.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+function CreateOpportunity() {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    alert('Opportunity posted!');
+    setTitle('');
+    setDescription('');
+  };
+
+  return (
+    <div className="container mt-5" style={{ maxWidth: 600 }}>
+      <h2>Create Opportunity</h2>
+      <form onSubmit={handleSubmit}>
+        <div className="mb-3">
+          <label className="form-label">Title</label>
+          <input type="text" className="form-control" value={title} onChange={(e) => setTitle(e.target.value)} required />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">Description</label>
+          <textarea className="form-control" value={description} onChange={(e) => setDescription(e.target.value)} required />
+        </div>
+        <button type="submit" className="btn btn-primary">Post</button>
+      </form>
+    </div>
+  );
+}
+
+export default CreateOpportunity;

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -1,0 +1,13 @@
+import SearchBar from "../components/SearchBar";
+
+function Dashboard() {
+  return (
+    <div className="container mt-5">
+      <SearchBar />
+      <h2 className="mt-4">Welcome to your Dashboard</h2>
+      <p>Select options from the navigation bar.</p>
+    </div>
+  );
+}
+
+export default Dashboard;

--- a/app/src/pages/LoginPage.tsx
+++ b/app/src/pages/LoginPage.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    navigate('/dashboard');
+  };
+
+  return (
+    <div className="container mt-5" style={{ maxWidth: 400 }}>
+      <h2>Login</h2>
+      <form onSubmit={handleSubmit}>
+        <div className="mb-3">
+          <label className="form-label">Email</label>
+          <input type="email" className="form-control" value={email} onChange={(e) => setEmail(e.target.value)} required />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">Password</label>
+          <input type="password" className="form-control" value={password} onChange={(e) => setPassword(e.target.value)} required />
+        </div>
+        <button type="submit" className="btn btn-primary w-100">Login</button>
+      </form>
+    </div>
+  );
+}
+
+export default LoginPage;

--- a/app/src/pages/RegisterPage.tsx
+++ b/app/src/pages/RegisterPage.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+function RegisterPage() {
+  const [form, setForm] = useState({
+    email: '',
+    phone: '',
+    password: '',
+    role: 'member',
+  });
+  const navigate = useNavigate();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    alert('Verification link would be sent to email/phone');
+    navigate('/login');
+  };
+
+  return (
+    <div className="container mt-5" style={{ maxWidth: 400 }}>
+      <h2>Register</h2>
+      <form onSubmit={handleSubmit}>
+        <div className="mb-3">
+          <label className="form-label">Email</label>
+          <input type="email" name="email" className="form-control" value={form.email} onChange={handleChange} required />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">Phone</label>
+          <input type="tel" name="phone" className="form-control" value={form.phone} onChange={handleChange} required />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">Password</label>
+          <input type="password" name="password" className="form-control" value={form.password} onChange={handleChange} required />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">Role</label>
+          <select className="form-select" name="role" value={form.role} onChange={handleChange}>
+            <option value="member">Community Member</option>
+            <option value="organization">Organization</option>
+          </select>
+        </div>
+        <button type="submit" className="btn btn-primary w-100">Register</button>
+      </form>
+    </div>
+  );
+}
+
+export default RegisterPage;

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/app/tsconfig.node.json
+++ b/app/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold a React app using Vite 4.1.0 with TypeScript
- add pages for login, registration, dashboard, creating opportunities and community
- add a search bar component and navigation links
- include basic README with setup instructions

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684f04f099f8832f9e1d57f63b667afd