### PR TITLE
Add error handling for fetch calls

### DIFF
--- a/myapp/src/components/Chat.tsx
+++ b/myapp/src/components/Chat.tsx
@@ -9,30 +9,39 @@ export default function Chat() {
   const [msgs, setMsgs] = useState([] as any[]);
 
   useEffect(() => {
-    getMessages().then(all =>
+    (async () => {
+      try {
+        const all = await getMessages();
+        setMsgs(
+          all.filter(
+            m =>
+              (m.from === current.email && m.to === email) ||
+              (m.from === email && m.to === current.email)
+          )
+        );
+      } catch {
+        alert('Failed to fetch messages');
+      }
+    })();
+  }, [email]);
+
+  const send = async () => {
+    if (!text) return;
+    try {
+      const all = await getMessages();
+      all.push({ from: current.email, to: email!, text, timestamp: Date.now() });
+      await saveMessages(all);
       setMsgs(
         all.filter(
           m =>
             (m.from === current.email && m.to === email) ||
             (m.from === email && m.to === current.email)
         )
-      )
-    );
-  }, [email]);
-
-  const send = async () => {
-    if (!text) return;
-    const all = await getMessages();
-    all.push({ from: current.email, to: email!, text, timestamp: Date.now() });
-    await saveMessages(all);
-    setMsgs(
-      all.filter(
-        m =>
-          (m.from === current.email && m.to === email) ||
-          (m.from === email && m.to === current.email)
-      )
-    );
-    setText('');
+      );
+      setText('');
+    } catch {
+      alert('Failed to send message');
+    }
   };
 
   return (

--- a/myapp/src/components/Community.tsx
+++ b/myapp/src/components/Community.tsx
@@ -12,22 +12,33 @@ export default function Community() {
     if (!u) return navigate('/login');
     const me = JSON.parse(u);
     setCurrent(me);
-    getUsers().then(all => setUsers(all.filter(x => x.email !== me.email)));
+    (async () => {
+      try {
+        const all = await getUsers();
+        setUsers(all.filter(x => x.email !== me.email));
+      } catch {
+        alert('Failed to fetch users');
+      }
+    })();
   }, [navigate]);
 
   const toggleFollow = async (email: string) => {
-    const all = await getUsers();
-    const idx = all.findIndex(u => u.email === current.email);
-    const followers = new Set(all[idx].followers);
-    if (followers.has(email)) {
-      followers.delete(email);
-    } else {
-      followers.add(email);
+    try {
+      const all = await getUsers();
+      const idx = all.findIndex(u => u.email === current.email);
+      const followers = new Set(all[idx].followers);
+      if (followers.has(email)) {
+        followers.delete(email);
+      } else {
+        followers.add(email);
+      }
+      all[idx].followers = Array.from(followers);
+      await saveUsers(all);
+      localStorage.setItem('currentUser', JSON.stringify(all[idx]));
+      setUsers(all.filter(x => x.email !== all[idx].email));
+    } catch {
+      alert('Failed to update users');
     }
-    all[idx].followers = Array.from(followers);
-    await saveUsers(all);
-    localStorage.setItem('currentUser', JSON.stringify(all[idx]));
-    setUsers(all.filter(x => x.email !== all[idx].email));
   };
 
   if (!current) return null;

--- a/myapp/src/components/Create.tsx
+++ b/myapp/src/components/Create.tsx
@@ -25,11 +25,15 @@ export default function Create() {
 
   const submit = async (e: any) => {
     e.preventDefault();
-    const posts = await getPosts();
-    posts.push({ id: Date.now(), orgEmail: user.email, title, description, postType, tags: [], applicants: [] });
-    await savePosts(posts);
-    alert('Created!');
-    navigate('/dashboard');
+    try {
+      const posts = await getPosts();
+      posts.push({ id: Date.now(), orgEmail: user.email, title, description, postType, tags: [], applicants: [] });
+      await savePosts(posts);
+      alert('Created!');
+      navigate('/dashboard');
+    } catch {
+      alert('Failed to create post');
+    }
   };
 
   return (

--- a/myapp/src/components/Dashboard.tsx
+++ b/myapp/src/components/Dashboard.tsx
@@ -16,7 +16,14 @@ export default function Dashboard() {
     } else {
       const parsed = JSON.parse(u);
       setUser(parsed);
-      getPosts().then(setPosts);
+      (async () => {
+        try {
+          const posts = await getPosts();
+          setPosts(posts);
+        } catch {
+          alert('Failed to fetch posts');
+        }
+      })();
     }
   }, [navigate]);
 
@@ -43,11 +50,15 @@ export default function Dashboard() {
                       type="button"
                       className="btn btn-sm btn-warning"
                       onClick={async () => {
-                        const all = await getPosts();
-                        const idx = all.findIndex(x => x.id === p.id);
-                        all[idx].applicants = all[idx].applicants.filter((a: string) => a !== user.email);
-                        await savePosts(all);
-                        setPosts(all);
+                        try {
+                          const all = await getPosts();
+                          const idx = all.findIndex(x => x.id === p.id);
+                          all[idx].applicants = all[idx].applicants.filter((a: string) => a !== user.email);
+                          await savePosts(all);
+                          setPosts(all);
+                        } catch {
+                          alert('Failed to update posts');
+                        }
                       }}
                     >
                     Withdraw
@@ -57,11 +68,15 @@ export default function Dashboard() {
                       type="button"
                       className="btn btn-sm btn-primary"
                       onClick={async () => {
-                        const all = await getPosts();
-                        const idx = all.findIndex(x => x.id === p.id);
-                        all[idx].applicants.push(user.email);
-                        await savePosts(all);
-                        setPosts(all);
+                        try {
+                          const all = await getPosts();
+                          const idx = all.findIndex(x => x.id === p.id);
+                          all[idx].applicants.push(user.email);
+                          await savePosts(all);
+                          setPosts(all);
+                        } catch {
+                          alert('Failed to update posts');
+                        }
                       }}
                     >
                     Apply

--- a/myapp/src/components/Groups.tsx
+++ b/myapp/src/components/Groups.tsx
@@ -6,17 +6,28 @@ export default function Groups({ userEmail }: { userEmail: string }) {
   const [groups, setGroups] = useState([] as any[]);
 
   useEffect(() => {
-    getGroups().then(all => setGroups(all.filter(g => g.members.includes(userEmail))));
+    (async () => {
+      try {
+        const all = await getGroups();
+        setGroups(all.filter(g => g.members.includes(userEmail)));
+      } catch {
+        alert('Failed to fetch groups');
+      }
+    })();
   }, [userEmail]);
 
   const createGroup = async () => {
     if (!name) return;
-    const all = await getGroups();
-    const id = Date.now();
-    all.push({ id, name, members: [userEmail] });
-    await saveGroups(all);
-    setGroups(all.filter(g => g.members.includes(userEmail)));
-    setName('');
+    try {
+      const all = await getGroups();
+      const id = Date.now();
+      all.push({ id, name, members: [userEmail] });
+      await saveGroups(all);
+      setGroups(all.filter(g => g.members.includes(userEmail)));
+      setName('');
+    } catch {
+      alert('Failed to update groups');
+    }
   };
 
   return (

--- a/myapp/src/components/Search.tsx
+++ b/myapp/src/components/Search.tsx
@@ -6,10 +6,15 @@ export default function Search() {
   const [results, setResults] = useState([] as any[]);
 
   useEffect(() => {
-    getPosts().then(posts => {
-      const q = query.toLowerCase();
-      setResults(posts.filter(p => p.title.toLowerCase().includes(q) || p.orgEmail.toLowerCase().includes(q)));
-    });
+    (async () => {
+      try {
+        const posts = await getPosts();
+        const q = query.toLowerCase();
+        setResults(posts.filter(p => p.title.toLowerCase().includes(q) || p.orgEmail.toLowerCase().includes(q)));
+      } catch {
+        alert('Failed to fetch posts');
+      }
+    })();
   }, [query]);
 
   return (

--- a/myapp/src/components/Verify.tsx
+++ b/myapp/src/components/Verify.tsx
@@ -7,13 +7,17 @@ export default function Verify() {
   const email = params.get('email') || '';
 
   const handleVerify = async () => {
-    const users = await getUsers();
-    const idx = users.findIndex(u => u.email === email);
-    if (idx !== -1) {
-      users[idx].verified = true;
-      await saveUsers(users);
-      alert('Account verified! You can now login.');
-      navigate('/login');
+    try {
+      const users = await getUsers();
+      const idx = users.findIndex(u => u.email === email);
+      if (idx !== -1) {
+        users[idx].verified = true;
+        await saveUsers(users);
+        alert('Account verified! You can now login.');
+        navigate('/login');
+      }
+    } catch {
+      alert('Failed to verify account');
     }
   };
 


### PR DESCRIPTION
## Summary
- wrap all data fetch and save calls in try/catch blocks
- show alert messages when network operations fail

## Testing
- `npm test --silent --prefix myapp`
- `npm run build --prefix myapp`


------
https://chatgpt.com/codex/tasks/task_e_684f3bbea278832f9cb312f3548c8464