### PR TITLE
Add groups view and group chat to community

### DIFF
--- a/myapp/prism-db.cjs
+++ b/myapp/prism-db.cjs
@@ -1,20 +1,46 @@
 // Minimal "Prism" style file database used for this demo
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
+
+const SECRET = 'aima-demo-secret-key-32chars!!';
+
+function encrypt(text) {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv('aes-256-ctr', Buffer.from(SECRET), iv);
+  const enc = Buffer.concat([cipher.update(text), cipher.final()]);
+  return iv.toString('hex') + ':' + enc.toString('hex');
+}
+
+function decrypt(text) {
+  const [ivHex, dataHex] = text.split(':');
+  const iv = Buffer.from(ivHex, 'hex');
+  const decipher = crypto.createDecipheriv('aes-256-ctr', Buffer.from(SECRET), iv);
+  const dec = Buffer.concat([
+    decipher.update(Buffer.from(dataHex, 'hex')),
+    decipher.final(),
+  ]);
+  return dec.toString();
+}
 
 const FILE = path.join(__dirname, 'db.json');
 const DEFAULT = { users: [], posts: [], groups: [], messages: [] };
 
 function read() {
   try {
-    return JSON.parse(fs.readFileSync(FILE, 'utf8'));
+    const text = fs.readFileSync(FILE, 'utf8');
+    if (text.trim().startsWith('{')) {
+      return JSON.parse(text);
+    }
+    return JSON.parse(decrypt(text));
   } catch {
     return { ...DEFAULT };
   }
 }
 
 function write(data) {
-  fs.writeFileSync(FILE, JSON.stringify(data, null, 2));
+  const enc = encrypt(JSON.stringify(data));
+  fs.writeFileSync(FILE, enc);
 }
 
 module.exports = {

--- a/myapp/prism-db.cjs
+++ b/myapp/prism-db.cjs
@@ -34,7 +34,9 @@ function read() {
       return JSON.parse(text);
     }
     return JSON.parse(decrypt(text));
-  } catch {
+  } catch (err) {
+    console.error('DB read failed, resetting file', err);
+    write({ ...DEFAULT });
     return { ...DEFAULT };
   }
 }

--- a/myapp/prism-db.cjs
+++ b/myapp/prism-db.cjs
@@ -3,7 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 
-const SECRET = 'aima-demo-secret-key-32chars!!';
+// Use a 32 byte key for AES-256 encryption
+const SECRET = 'aima-demo-secret-key-32-chars-!!';
 
 function encrypt(text) {
   const iv = crypto.randomBytes(16);

--- a/myapp/src/App.tsx
+++ b/myapp/src/App.tsx
@@ -19,6 +19,7 @@ import Calendar from './components/Calendar';
 import Notes from './components/Notes';
 import PeopleMap from './components/PeopleMap';
 import Interview from './components/Interview';
+import Forgot from './components/Forgot';
 
 function App() {
   return (
@@ -27,6 +28,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
+        <Route path="/forgot" element={<Forgot />} />
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/create" element={<Create />} />
         <Route path="/community" element={<Community />} />

--- a/myapp/src/App.tsx
+++ b/myapp/src/App.tsx
@@ -14,6 +14,7 @@ import Community from './components/Community';
 import Search from './components/Search';
 import Chat from './components/Chat';
 import Jobs from './components/Jobs';
+import Profile from './components/Profile';
 
 function App() {
   return (
@@ -29,6 +30,7 @@ function App() {
         <Route path="/jobs" element={<Jobs />} />
         <Route path="/verify" element={<Verify />} />
         <Route path="/chat/:email" element={<Chat />} />
+        <Route path="/profile/:email" element={<Profile />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </Router>

--- a/myapp/src/App.tsx
+++ b/myapp/src/App.tsx
@@ -15,6 +15,10 @@ import Search from './components/Search';
 import Chat from './components/Chat';
 import Jobs from './components/Jobs';
 import Profile from './components/Profile';
+import Calendar from './components/Calendar';
+import Notes from './components/Notes';
+import PeopleMap from './components/PeopleMap';
+import Interview from './components/Interview';
 
 function App() {
   return (
@@ -31,6 +35,10 @@ function App() {
         <Route path="/verify" element={<Verify />} />
         <Route path="/chat/:email" element={<Chat />} />
         <Route path="/profile/:email" element={<Profile />} />
+        <Route path="/calendar" element={<Calendar />} />
+        <Route path="/notes" element={<Notes />} />
+        <Route path="/people-map" element={<PeopleMap />} />
+        <Route path="/interview" element={<Interview />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </Router>

--- a/myapp/src/components/Calendar.tsx
+++ b/myapp/src/components/Calendar.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Nav from './Nav';
+import { getUsers, saveUsers } from '../utils';
+import { CalendarEvent } from '../types';
+
+export default function Calendar() {
+  const navigate = useNavigate();
+  const [user, setUser] = useState(null as any);
+  const [title, setTitle] = useState('');
+  const [date, setDate] = useState('');
+
+  useEffect(() => {
+    const u = localStorage.getItem('currentUser');
+    if (!u) return navigate('/login');
+    setUser(JSON.parse(u));
+  }, [navigate]);
+
+  if (!user) return null;
+
+  const addEvent = async () => {
+    if (!title || !date) return;
+    const all = await getUsers();
+    const idx = all.findIndex(u => u.email === user.email);
+    const ev: CalendarEvent = {
+      id: Date.now(),
+      title,
+      date,
+      alert: false,
+    };
+    if (!all[idx].events) all[idx].events = [];
+    all[idx].events.push(ev);
+    await saveUsers(all);
+    localStorage.setItem('currentUser', JSON.stringify(all[idx]));
+    setUser(all[idx]);
+    setTitle('');
+    setDate('');
+  };
+
+  const toggleAlert = async (id: number) => {
+    const all = await getUsers();
+    const idx = all.findIndex(u => u.email === user.email);
+    const ev = all[idx].events.find((e: CalendarEvent) => e.id === id);
+    if (ev) ev.alert = !ev.alert;
+    await saveUsers(all);
+    localStorage.setItem('currentUser', JSON.stringify(all[idx]));
+    setUser(all[idx]);
+  };
+
+  const removeEvent = async (id: number) => {
+    const all = await getUsers();
+    const idx = all.findIndex(u => u.email === user.email);
+    all[idx].events = all[idx].events.filter((e: CalendarEvent) => e.id !== id);
+    await saveUsers(all);
+    localStorage.setItem('currentUser', JSON.stringify(all[idx]));
+    setUser(all[idx]);
+  };
+
+  return (
+    <div>
+      <Nav />
+      <div className="container my-4" style={{ maxWidth: '600px' }}>
+        <h2>Calendar</h2>
+        <form
+          className="mb-3"
+          onSubmit={e => {
+            e.preventDefault();
+            addEvent();
+          }}
+        >
+          <input
+            className="form-control mb-2"
+            placeholder="Event title"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+          />
+          <input
+            type="datetime-local"
+            className="form-control mb-2"
+            value={date}
+            onChange={e => setDate(e.target.value)}
+          />
+          <button type="submit" className="btn btn-primary">
+            Add Event
+          </button>
+        </form>
+        <ul className="list-group">
+          {user.events.map((e: CalendarEvent) => (
+            <li key={e.id} className="list-group-item d-flex justify-content-between align-items-center">
+              <span>
+                {e.title} - {new Date(e.date).toLocaleString()}
+                {e.alert && <span className="badge bg-info text-dark ms-2">alert</span>}
+              </span>
+              <span>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary me-2"
+                  onClick={() => toggleAlert(e.id)}
+                >
+                  {e.alert ? 'Clear' : 'Alert'}
+                </button>
+                <button type="button" className="btn btn-sm btn-danger" onClick={() => removeEvent(e.id)}>
+                  Delete
+                </button>
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/myapp/src/components/Chat.tsx
+++ b/myapp/src/components/Chat.tsx
@@ -1,23 +1,37 @@
 import { useParams } from 'react-router-dom';
 import { useState, useEffect } from 'react';
-import { getMessages, saveMessages } from '../utils';
+import { getMessages, saveMessages, getGroups } from '../utils';
 
 export default function Chat() {
   const { email } = useParams();
   const current = JSON.parse(localStorage.getItem('currentUser') || '{}');
   const [text, setText] = useState('');
   const [msgs, setMsgs] = useState([] as any[]);
+  const [targetName, setTargetName] = useState(email || '');
 
   useEffect(() => {
     getMessages().then(all =>
       setMsgs(
-        all.filter(
-          m =>
+        all.filter(m => {
+          if (email?.startsWith('group-')) {
+            return m.to === email;
+          }
+          return (
             (m.from === current.email && m.to === email) ||
             (m.from === email && m.to === current.email)
-        )
+          );
+        })
       )
     );
+    if (email?.startsWith('group-')) {
+      const id = parseInt(email.slice(6), 10);
+      getGroups().then(gs => {
+        const g = gs.find(x => x.id === id);
+        setTargetName(g ? g.name : email);
+      });
+    } else {
+      setTargetName(email || '');
+    }
   }, [email]);
 
   const send = async () => {
@@ -26,11 +40,15 @@ export default function Chat() {
     all.push({ from: current.email, to: email!, text, timestamp: Date.now() });
     await saveMessages(all);
     setMsgs(
-      all.filter(
-        m =>
+      all.filter(m => {
+        if (email?.startsWith('group-')) {
+          return m.to === email;
+        }
+        return (
           (m.from === current.email && m.to === email) ||
           (m.from === email && m.to === current.email)
-      )
+        );
+      })
     );
     setText('');
   };
@@ -39,7 +57,7 @@ export default function Chat() {
     <div className="container my-4" style={{ maxWidth: '500px' }}>
       <div className="card">
         <div className="card-body">
-          <h3 className="card-title">Chat with {email}</h3>
+          <h3 className="card-title">Chat with {targetName}</h3>
           <div
             style={{
               height: '200px',

--- a/myapp/src/components/Chat.tsx
+++ b/myapp/src/components/Chat.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { useState, useEffect } from 'react';
-import { getMessages, saveMessages, getGroups } from '../utils';
+import { getMessages, saveMessages, getGroups, getUsers } from '../utils';
 
 export default function Chat() {
   const { email } = useParams();
@@ -8,6 +8,7 @@ export default function Chat() {
   const [text, setText] = useState('');
   const [msgs, setMsgs] = useState([] as any[]);
   const [targetName, setTargetName] = useState(email || '');
+  const [canChat, setCanChat] = useState(true);
 
   useEffect(() => {
     getMessages().then(all =>
@@ -23,6 +24,15 @@ export default function Chat() {
         })
       )
     );
+    if (!email) return;
+    getUsers().then(us => {
+      const me = us.find(u => u.email === current.email);
+      const other = us.find(u => u.email === email);
+      const blocked =
+        other?.blocked?.includes(current.email) || me?.blocked?.includes(email);
+      const snoozed = me?.snoozed || other?.snoozed;
+      setCanChat(!blocked && !snoozed);
+    });
     if (email?.startsWith('group-')) {
       const id = parseInt(email.slice(6), 10);
       getGroups().then(gs => {
@@ -35,7 +45,7 @@ export default function Chat() {
   }, [email]);
 
   const send = async () => {
-    if (!text) return;
+    if (!text || !canChat) return;
     const all = await getMessages();
     all.push({ from: current.email, to: email!, text, timestamp: Date.now() });
     await saveMessages(all);
@@ -78,11 +88,15 @@ export default function Chat() {
               className="form-control"
               value={text}
               onChange={e => setText(e.target.value)}
+              disabled={!canChat}
             />
-            <button type="button" className="btn btn-primary" onClick={send}>
+            <button type="button" className="btn btn-primary" onClick={send} disabled={!canChat}>
               Send
             </button>
           </div>
+          {!canChat && (
+            <div className="text-danger mt-2">Messaging is unavailable (blocked or snoozed)</div>
+          )}
         </div>
       </div>
     </div>

--- a/myapp/src/components/Community.tsx
+++ b/myapp/src/components/Community.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { getUsers, saveUsers } from '../utils';
+import { getUsers, saveUsers, getGroups, saveGroups } from '../utils';
 
 export default function Community() {
   const [current, setCurrent] = useState(null as any);
   const [users, setUsers] = useState([] as any[]);
+  const [groups, setGroups] = useState([] as any[]);
+  const [view, setView] = useState('members' as 'members' | 'groups');
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -13,6 +15,7 @@ export default function Community() {
     const me = JSON.parse(u);
     setCurrent(me);
     getUsers().then(all => setUsers(all.filter(x => x.email !== me.email)));
+    getGroups().then(gs => setGroups(gs));
   }, [navigate]);
 
   const toggleFollow = async (email: string) => {
@@ -30,6 +33,20 @@ export default function Community() {
     setUsers(all.filter(x => x.email !== all[idx].email));
   };
 
+  const toggleJoinGroup = async (id: number) => {
+    const all = await getGroups();
+    const idx = all.findIndex(g => g.id === id);
+    const members = new Set(all[idx].members);
+    if (members.has(current.email)) {
+      members.delete(current.email);
+    } else {
+      members.add(current.email);
+    }
+    all[idx].members = Array.from(members);
+    await saveGroups(all);
+    setGroups(all);
+  };
+
   if (!current) return null;
 
   return (
@@ -37,28 +54,76 @@ export default function Community() {
       <div className="card">
         <div className="card-body">
           <h2 className="card-title mb-3">Community</h2>
-          <ul className="list-group list-group-flush">
-            {users.map(u => (
-              <li
-                key={u.email}
-                className="list-group-item d-flex justify-content-between align-items-center"
-              >
-                <span>{u.email}</span>
-                <div>
-                  <button
-                    type="button"
-                    className="btn btn-sm btn-outline-primary me-2"
-                    onClick={() => toggleFollow(u.email)}
-                  >
-                    {current.followers.includes(u.email) ? 'Unfollow' : 'Follow'}
-                  </button>
-                  <Link to={`/chat/${u.email}`} className="btn btn-sm btn-secondary">
-                    Message
-                  </Link>
-                </div>
-              </li>
-            ))}
-          </ul>
+          <nav className="nav nav-tabs mb-3">
+            <button
+              type="button"
+              className={`nav-link ${view === 'members' ? 'active' : ''}`}
+              onClick={() => setView('members')}
+            >
+              Members
+            </button>
+            <button
+              type="button"
+              className={`nav-link ${view === 'groups' ? 'active' : ''}`}
+              onClick={() => setView('groups')}
+            >
+              Groups
+            </button>
+          </nav>
+          {view === 'members' && (
+            <ul className="list-group list-group-flush">
+              {users.map(u => (
+                <li
+                  key={u.email}
+                  className="list-group-item d-flex justify-content-between align-items-center"
+                >
+                  <span>{u.email}</span>
+                  <div>
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-primary me-2"
+                      onClick={() => toggleFollow(u.email)}
+                    >
+                      {current.followers.includes(u.email) ? 'Unfollow' : 'Follow'}
+                    </button>
+                    <Link
+                      to={`/chat/${u.email}`}
+                      className="btn btn-sm btn-secondary"
+                    >
+                      Message
+                    </Link>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+          {view === 'groups' && (
+            <ul className="list-group list-group-flush">
+              {groups.map(g => (
+                <li
+                  key={g.id}
+                  className="list-group-item d-flex justify-content-between align-items-center"
+                >
+                  <span>{g.name}</span>
+                  <div>
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-primary me-2"
+                      onClick={() => toggleJoinGroup(g.id)}
+                    >
+                      {g.members.includes(current.email) ? 'Leave' : 'Join'}
+                    </button>
+                    <Link
+                      to={`/chat/group-${g.id}`}
+                      className="btn btn-sm btn-secondary"
+                    >
+                      Message
+                    </Link>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       </div>
     </div>

--- a/myapp/src/components/Community.tsx
+++ b/myapp/src/components/Community.tsx
@@ -47,6 +47,17 @@ export default function Community() {
     setGroups(all);
   };
 
+  const requestProfile = async (email: string) => {
+    const all = await getUsers();
+    const idx = all.findIndex(u => u.email === email);
+    if (!all[idx].profileRequests) all[idx].profileRequests = [];
+    if (!all[idx].profileRequests.includes(current.email)) {
+      all[idx].profileRequests.push(current.email);
+      await saveUsers(all);
+      setUsers(all.filter(x => x.email !== current.email));
+    }
+  };
+
   if (!current) return null;
 
   return (
@@ -86,10 +97,26 @@ export default function Community() {
                     >
                       {current.followers.includes(u.email) ? 'Unfollow' : 'Follow'}
                     </button>
-                    <Link
-                      to={`/chat/${u.email}`}
-                      className="btn btn-sm btn-secondary"
-                    >
+                    {u.profileShares && u.profileShares.includes(current.email) ? (
+                      <Link
+                        to={`/profile/${u.email}`}
+                        className="btn btn-sm btn-outline-info me-2"
+                      >
+                        View Profile
+                      </Link>
+                    ) : (
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-info me-2"
+                        onClick={() => requestProfile(u.email)}
+                        disabled={u.profileRequests && u.profileRequests.includes(current.email)}
+                      >
+                        {u.profileRequests && u.profileRequests.includes(current.email)
+                          ? 'Requested'
+                          : 'Request Profile'}
+                      </button>
+                    )}
+                    <Link to={`/chat/${u.email}`} className="btn btn-sm btn-secondary">
                       Message
                     </Link>
                   </div>

--- a/myapp/src/components/Community.tsx
+++ b/myapp/src/components/Community.tsx
@@ -58,6 +58,18 @@ export default function Community() {
     }
   };
 
+  const toggleBlock = async (email: string) => {
+    const all = await getUsers();
+    const idx = all.findIndex(u => u.email === current.email);
+    const set = new Set(all[idx].blocked || []);
+    if (set.has(email)) set.delete(email); else set.add(email);
+    all[idx].blocked = Array.from(set);
+    await saveUsers(all);
+    localStorage.setItem('currentUser', JSON.stringify(all[idx]));
+    setCurrent(all[idx]);
+    setUsers(all.filter(x => x.email !== all[idx].email));
+  };
+
   const profileComplete = (u: any) =>
     u.skills && u.skills.length > 0 && u.bio && u.resume;
 
@@ -146,6 +158,15 @@ export default function Community() {
                     <Link to={`/chat/${u.email}`} className="btn btn-sm btn-secondary">
                       Message
                     </Link>
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-danger ms-2"
+                      onClick={() => toggleBlock(u.email)}
+                    >
+                      {current.blocked && current.blocked.includes(u.email)
+                        ? 'Unblock'
+                        : 'Block'}
+                    </button>
                     {profileComplete(current) && profileComplete(u) && (
                       <button
                         type="button"

--- a/myapp/src/components/Community.tsx
+++ b/myapp/src/components/Community.tsx
@@ -58,6 +58,33 @@ export default function Community() {
     }
   };
 
+  const profileComplete = (u: any) =>
+    u.skills && u.skills.length > 0 && u.bio && u.resume;
+
+  const recommend = async (email: string) => {
+    const target = users.find(x => x.email === email);
+    if (!profileComplete(current)) {
+      alert('Complete your profile before giving a recommendation.');
+      return;
+    }
+    if (!target || !profileComplete(target)) {
+      alert('User must have a complete profile to receive recommendations.');
+      return;
+    }
+    const text = prompt('Enter your recommendation');
+    if (!text) return;
+    const all = await getUsers();
+    const idx = all.findIndex(u => u.email === email);
+    if (!all[idx].recommendations) all[idx].recommendations = [];
+    all[idx].recommendations.push({
+      from: current.email,
+      text,
+      timestamp: Date.now(),
+    });
+    await saveUsers(all);
+    setUsers(all.filter(x => x.email !== current.email));
+  };
+
   if (!current) return null;
 
   return (
@@ -119,6 +146,15 @@ export default function Community() {
                     <Link to={`/chat/${u.email}`} className="btn btn-sm btn-secondary">
                       Message
                     </Link>
+                    {profileComplete(current) && profileComplete(u) && (
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-success ms-2"
+                        onClick={() => recommend(u.email)}
+                      >
+                        Recommend
+                      </button>
+                    )}
                   </div>
                 </li>
               ))}

--- a/myapp/src/components/Create.tsx
+++ b/myapp/src/components/Create.tsx
@@ -30,6 +30,7 @@ export default function Create() {
       postType,
       tags: [],
       applicants: [],
+      statuses: {},
       comments: [],
     });
     await savePosts(posts);

--- a/myapp/src/components/Create.tsx
+++ b/myapp/src/components/Create.tsx
@@ -13,11 +13,6 @@ export default function Create() {
     const u = localStorage.getItem('currentUser');
     if (!u) return navigate('/login');
     const parsed = JSON.parse(u);
-    if (parsed.type !== 'org') {
-      alert('Only organizations can create posts.');
-      navigate('/dashboard');
-      return;
-    }
     setUser(parsed);
   }, [navigate]);
 
@@ -26,7 +21,17 @@ export default function Create() {
   const submit = async (e: any) => {
     e.preventDefault();
     const posts = await getPosts();
-    posts.push({ id: Date.now(), orgEmail: user.email, title, description, postType, tags: [], applicants: [] });
+    posts.push({
+      id: Date.now(),
+      authorEmail: user.email,
+      authorType: user.type,
+      title,
+      description,
+      postType,
+      tags: [],
+      applicants: [],
+      comments: [],
+    });
     await savePosts(posts);
     alert('Created!');
     navigate('/dashboard');
@@ -36,7 +41,7 @@ export default function Create() {
     <div className="container my-4" style={{ maxWidth: '600px' }}>
       <div className="card">
         <div className="card-body">
-          <h2 className="card-title mb-3">Create Opportunity</h2>
+          <h2 className="card-title mb-3">Create Post</h2>
           <form onSubmit={submit}>
             <div className="mb-3">
               <label className="form-label">Title</label>

--- a/myapp/src/components/Dashboard.tsx
+++ b/myapp/src/components/Dashboard.tsx
@@ -32,7 +32,8 @@ export default function Dashboard() {
 
   const memberGroups = allGroups.filter(g => g.members.includes(user.email));
   const otherMembers = users.filter(
-    u => u.type === 'member' && u.email !== user.email
+    u =>
+      (u.type === 'member' || u.type === 'candidate') && u.email !== user.email
   );
   const orgsOffering = users.filter(
     u => u.type === 'org' && posts.some(p => p.authorEmail === u.email)
@@ -51,7 +52,7 @@ export default function Dashboard() {
       return contact || sameGroup;
     }
     if (p.authorType === 'org') {
-      return user.type === 'member';
+      return user.type === 'member' || user.type === 'candidate';
     }
     return false;
   };
@@ -236,7 +237,7 @@ export default function Dashboard() {
               <li key={p.id} className="list-group-item">
                 <strong>{p.title}</strong> ({p.postType}) by {p.authorEmail}
                 <p>{p.description}</p>
-                {user.type === 'member' && (
+                {(user.type === 'member' || user.type === 'candidate') && (
                   p.applicants.includes(user.email) ? (
                     <button
                       type="button"
@@ -256,12 +257,26 @@ export default function Dashboard() {
                       type="button"
                       className="btn btn-sm btn-primary"
                       onClick={async () => {
+                        if (
+                          user.type === 'candidate' && (!user.skills || user.skills.length === 0)
+                        ) {
+                          alert('Please complete your profile before applying.');
+                          return;
+                        }
                         const all = await getPosts();
                         const idx = all.findIndex(x => x.id === p.id);
                         all[idx].applicants.push(user.email);
                         await savePosts(all);
                         setPosts(all);
                       }}
+                      disabled={
+                        user.type === 'candidate' && (!user.skills || user.skills.length === 0)
+                      }
+                      title={
+                        user.type === 'candidate' && (!user.skills || user.skills.length === 0)
+                          ? 'Complete your profile to apply'
+                          : undefined
+                      }
                     >
                       Apply
                     </button>

--- a/myapp/src/components/Dashboard.tsx
+++ b/myapp/src/components/Dashboard.tsx
@@ -267,6 +267,13 @@ export default function Dashboard() {
                     </button>
                   )
                 )}
+                {p.applicants.includes(user.email) && (
+                  <div className="mt-2">
+                    <small className="text-muted">
+                      Status: {p.statuses[user.email] || 'applied'}
+                    </small>
+                  </div>
+                )}
                 <div className="mt-2">
                   <strong>Comments</strong>
                   <ul className="list-group mb-2">

--- a/myapp/src/components/Dashboard.tsx
+++ b/myapp/src/components/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Nav from './Nav';
-import { getPosts, savePosts, getUsers, getGroups } from '../utils';
+import { getPosts, savePosts, getUsers, getGroups, saveUsers } from '../utils';
 
 export default function Dashboard() {
   const navigate = useNavigate();
@@ -18,6 +18,9 @@ export default function Dashboard() {
     } else {
       const parsed = JSON.parse(u);
       setUser(parsed);
+      setResumeText(parsed.resume || '');
+      setBio(parsed.bio || '');
+      setSkillsInput((parsed.skills || []).join(', '));
       Promise.all([getPosts(), getUsers(), getGroups()]).then(
         ([p, us, gs]) => {
           setPosts(p);
@@ -58,6 +61,10 @@ export default function Dashboard() {
   };
 
   const [commentText, setCommentText] = useState({} as any);
+  const [resumeText, setResumeText] = useState('');
+  const [bio, setBio] = useState('');
+  const [skillsInput, setSkillsInput] = useState('');
+  const [docName, setDocName] = useState('');
 
   return (
     <div>
@@ -151,9 +158,135 @@ export default function Dashboard() {
         )}
 
         {active === 'profile' && (
-          <div>
+          <div style={{ maxWidth: '600px' }}>
             <h4>Member Profile</h4>
-            <p>User type: {user.type}</p>
+            <form
+              onSubmit={async e => {
+                e.preventDefault();
+                const all = await getUsers();
+                const idx = all.findIndex(u => u.email === user.email);
+                all[idx].resume = resumeText;
+                all[idx].bio = bio;
+                all[idx].skills = skillsInput
+                  .split(',')
+                  .map(s => s.trim())
+                  .filter(s => s);
+                all[idx].docs = user.docs || [];
+                await saveUsers(all);
+                localStorage.setItem('currentUser', JSON.stringify(all[idx]));
+                setUser(all[idx]);
+              }}
+            >
+              <div className="mb-3">
+                <label className="form-label">Skills (comma separated)</label>
+                <input
+                  className="form-control"
+                  value={skillsInput}
+                  onChange={e => setSkillsInput(e.target.value)}
+                />
+              </div>
+              <div className="mb-3">
+                <label className="form-label">Bio</label>
+                <textarea
+                  className="form-control"
+                  value={bio}
+                  onChange={e => setBio(e.target.value)}
+                />
+              </div>
+              <div className="mb-3">
+                <label className="form-label">Resume Text</label>
+                <textarea
+                  className="form-control"
+                  value={resumeText}
+                  onChange={e => setResumeText(e.target.value)}
+                />
+                <button
+                  type="button"
+                  className="btn btn-sm btn-secondary mt-1"
+                  onClick={() => {
+                    const match = resumeText.match(/skills?:\s*(.*)/i);
+                    if (match) setSkillsInput(match[1]);
+                    if (!bio) setBio(resumeText.slice(0, 200));
+                  }}
+                >
+                  Upload Resume
+                </button>
+              </div>
+              <div className="mb-3">
+                <label className="form-label">Add Document</label>
+                <input
+                  className="form-control"
+                  value={docName}
+                  onChange={e => setDocName(e.target.value)}
+                />
+                <button
+                  type="button"
+                  className="btn btn-sm btn-secondary mt-1"
+                  onClick={() => {
+                    if (!docName) return;
+                    const docs = user.docs ? [...user.docs, docName] : [docName];
+                    setUser({ ...user, docs });
+                    setDocName('');
+                  }}
+                >
+                  Add Document
+                </button>
+              </div>
+              {user.docs && user.docs.length > 0 && (
+                <ul className="list-group mb-3">
+                  {user.docs.map((d: string, i: number) => (
+                    <li key={i} className="list-group-item">
+                      {d}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <button type="submit" className="btn btn-primary">
+                Save Profile
+              </button>
+            </form>
+
+            <div className="mt-4">
+              <h5>Profile View Requests</h5>
+              <ul className="list-group">
+                {(user.profileRequests || []).map((r: string) => (
+                  <li key={r} className="list-group-item d-flex justify-content-between align-items-center">
+                    {r}
+                    <span>
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-success me-2"
+                        onClick={async () => {
+                          const all = await getUsers();
+                          const idx = all.findIndex(u => u.email === user.email);
+                          all[idx].profileRequests = all[idx].profileRequests.filter((x: string) => x !== r);
+                          all[idx].profileShares = [...(all[idx].profileShares || []), r];
+                          await saveUsers(all);
+                          localStorage.setItem('currentUser', JSON.stringify(all[idx]));
+                          setUser(all[idx]);
+                        }}
+                      >
+                        Accept
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-danger"
+                        onClick={async () => {
+                          const all = await getUsers();
+                          const idx = all.findIndex(u => u.email === user.email);
+                          all[idx].profileRequests = all[idx].profileRequests.filter((x: string) => x !== r);
+                          await saveUsers(all);
+                          localStorage.setItem('currentUser', JSON.stringify(all[idx]));
+                          setUser(all[idx]);
+                        }}
+                      >
+                        Decline
+                      </button>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </div>
         )}
 

--- a/myapp/src/components/Dashboard.tsx
+++ b/myapp/src/components/Dashboard.tsx
@@ -42,8 +42,7 @@ export default function Dashboard() {
 
   const memberGroups = allGroups.filter(g => g.members.includes(user.email));
   const otherMembers = users.filter(
-    u =>
-      (u.type === 'member' || u.type === 'candidate') && u.email !== user.email
+    u => u.type === 'member' && u.email !== user.email
   );
   const orgsOffering = users.filter(
     u => u.type === 'org' && posts.some(p => p.authorEmail === u.email)
@@ -62,7 +61,7 @@ export default function Dashboard() {
       return contact || sameGroup;
     }
     if (p.authorType === 'org') {
-      return user.type === 'member' || user.type === 'candidate';
+      return user.type === 'member';
     }
     return false;
   };
@@ -492,7 +491,7 @@ export default function Dashboard() {
               <li key={p.id} className="list-group-item">
                 <strong>{p.title}</strong> ({p.postType}) by {p.authorEmail}
                 <p>{p.description}</p>
-                {(user.type === 'member' || user.type === 'candidate') && (
+                {user.type === 'member' && (
                   p.applicants.includes(user.email) ? (
                     <button
                       type="button"
@@ -512,9 +511,7 @@ export default function Dashboard() {
                       type="button"
                       className="btn btn-sm btn-primary"
                       onClick={async () => {
-                        if (
-                          user.type === 'candidate' && (!user.skills || user.skills.length === 0)
-                        ) {
+                        if (!user.skills || user.skills.length === 0) {
                           alert('Please complete your profile before applying.');
                           return;
                         }
@@ -524,11 +521,9 @@ export default function Dashboard() {
                         await savePosts(all);
                         setPosts(all);
                       }}
-                      disabled={
-                        user.type === 'candidate' && (!user.skills || user.skills.length === 0)
-                      }
+                      disabled={!user.skills || user.skills.length === 0}
                       title={
-                        user.type === 'candidate' && (!user.skills || user.skills.length === 0)
+                        !user.skills || user.skills.length === 0
                           ? 'Complete your profile to apply'
                           : undefined
                       }

--- a/myapp/src/components/Dashboard.tsx
+++ b/myapp/src/components/Dashboard.tsx
@@ -287,6 +287,18 @@ export default function Dashboard() {
                 ))}
               </ul>
             </div>
+            {user.recommendations && user.recommendations.length > 0 && (
+              <div className="mt-4">
+                <h5>Recommendations</h5>
+                <ul className="list-group">
+                  {user.recommendations.map((r: any, i: number) => (
+                    <li key={i} className="list-group-item">
+                      <strong>{r.from}</strong>: {r.text}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </div>
         )}
 
@@ -308,8 +320,26 @@ export default function Dashboard() {
             <h4>Other Members</h4>
             <ul className="list-group mb-3">
               {otherMembers.map(m => (
-                <li key={m.email} className="list-group-item">
-                  {m.email}
+                <li key={m.email} className="list-group-item d-flex justify-content-between align-items-center">
+                  <span>{m.email}</span>
+                  {m.skills && m.skills.length > 0 && user.skills && user.skills.length > 0 && m.bio && m.resume && user.bio && user.resume && (
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-success"
+                      onClick={async () => {
+                        const text = prompt('Enter your recommendation');
+                        if (!text) return;
+                        const all = await getUsers();
+                        const idx = all.findIndex(u => u.email === m.email);
+                        if (!all[idx].recommendations) all[idx].recommendations = [];
+                        all[idx].recommendations.push({ from: user.email, text, timestamp: Date.now() });
+                        await saveUsers(all);
+                        setUsers(all);
+                      }}
+                    >
+                      Recommend
+                    </button>
+                  )}
                 </li>
               ))}
             </ul>

--- a/myapp/src/components/Dashboard.tsx
+++ b/myapp/src/components/Dashboard.tsx
@@ -35,11 +35,28 @@ export default function Dashboard() {
     u => u.type === 'member' && u.email !== user.email
   );
   const orgsOffering = users.filter(
-    u => u.type === 'org' && posts.some(p => p.orgEmail === u.email)
+    u => u.type === 'org' && posts.some(p => p.authorEmail === u.email)
   );
   const otherOrgs = users.filter(
-    u => u.type === 'org' && !posts.some(p => p.orgEmail === u.email)
+    u => u.type === 'org' && !posts.some(p => p.authorEmail === u.email)
   );
+
+  const canComment = (p: any) => {
+    if (p.authorType === 'member') {
+      if (p.authorEmail === user.email) return true;
+      const contact = user.followers.includes(p.authorEmail);
+      const sameGroup = allGroups.some(
+        g => g.members.includes(user.email) && g.members.includes(p.authorEmail)
+      );
+      return contact || sameGroup;
+    }
+    if (p.authorType === 'org') {
+      return user.type === 'member';
+    }
+    return false;
+  };
+
+  const [commentText, setCommentText] = useState({} as any);
 
   return (
     <div>
@@ -217,9 +234,9 @@ export default function Dashboard() {
           <ul className="list-group list-group-flush">
             {posts.map(p => (
               <li key={p.id} className="list-group-item">
-                <strong>{p.title}</strong> ({p.postType}) by {p.orgEmail}
+                <strong>{p.title}</strong> ({p.postType}) by {p.authorEmail}
                 <p>{p.description}</p>
-              {user.type === 'member' && (
+                {user.type === 'member' && (
                   p.applicants.includes(user.email) ? (
                     <button
                       type="button"
@@ -232,9 +249,9 @@ export default function Dashboard() {
                         setPosts(all);
                       }}
                     >
-                    Withdraw
-                  </button>
-                ) : (
+                      Withdraw
+                    </button>
+                  ) : (
                     <button
                       type="button"
                       className="btn btn-sm btn-primary"
@@ -246,12 +263,56 @@ export default function Dashboard() {
                         setPosts(all);
                       }}
                     >
-                    Apply
-                  </button>
-                )
-              )}
-            </li>
-          ))}
+                      Apply
+                    </button>
+                  )
+                )}
+                <div className="mt-2">
+                  <strong>Comments</strong>
+                  <ul className="list-group mb-2">
+                    {p.comments.map((c: any, i: number) => (
+                      <li key={i} className="list-group-item">
+                        <small>{c.userEmail}</small>: {c.text}
+                      </li>
+                    ))}
+                  </ul>
+                  {canComment(p) && (
+                    <form
+                      className="d-flex"
+                      onSubmit={async e => {
+                        e.preventDefault();
+                        const text = commentText[p.id] || '';
+                        if (!text) return;
+                        const all = await getPosts();
+                        const idx = all.findIndex(x => x.id === p.id);
+                        all[idx].comments.push({
+                          userEmail: user.email,
+                          text,
+                          timestamp: Date.now(),
+                        });
+                        await savePosts(all);
+                        setPosts(all);
+                        setCommentText({ ...commentText, [p.id]: '' });
+                      }}
+                    >
+                      <input
+                        className="form-control form-control-sm me-2"
+                        value={commentText[p.id] || ''}
+                        onChange={e =>
+                          setCommentText({
+                            ...commentText,
+                            [p.id]: e.target.value,
+                          })
+                        }
+                      />
+                      <button type="submit" className="btn btn-sm btn-secondary">
+                        Comment
+                      </button>
+                    </form>
+                  )}
+                </div>
+              </li>
+            ))}
           </ul>
         </div>
       </div>

--- a/myapp/src/components/Dashboard.tsx
+++ b/myapp/src/components/Dashboard.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Nav from './Nav';
-import { getPosts, savePosts, getUsers, getGroups, saveUsers } from '../utils';
+import {
+  getPosts,
+  savePosts,
+  getUsers,
+  getGroups,
+  saveUsers,
+  hashString,
+} from '../utils';
 
 export default function Dashboard() {
   const navigate = useNavigate();
@@ -65,6 +72,8 @@ export default function Dashboard() {
   const [bio, setBio] = useState('');
   const [skillsInput, setSkillsInput] = useState('');
   const [docName, setDocName] = useState('');
+  const [oldPass, setOldPass] = useState('');
+  const [newPass, setNewPass] = useState('');
 
   return (
     <div>
@@ -147,13 +156,96 @@ export default function Dashboard() {
         )}
 
         {active === 'settings' && (
-          <div>
+          <div style={{ maxWidth: '500px' }}>
             <h4>Member Settings</h4>
             <p>
               Email: {user.email}
               <br />
               Phone: {user.phone}
             </p>
+            <form
+              className="mb-3"
+              onSubmit={async e => {
+                e.preventDefault();
+                const all = await getUsers();
+                const idx = all.findIndex(u => u.email === user.email);
+                const hashedOld = await hashString(oldPass);
+                if (all[idx].password !== hashedOld) {
+                  alert('Current password incorrect');
+                  return;
+                }
+                all[idx].password = await hashString(newPass);
+                await saveUsers(all);
+                localStorage.setItem('currentUser', JSON.stringify(all[idx]));
+                setUser(all[idx]);
+                setOldPass('');
+                setNewPass('');
+                alert('Password updated');
+              }}
+            >
+              <div className="mb-2">
+                <label className="form-label">Current Password</label>
+                <input
+                  type="password"
+                  className="form-control"
+                  value={oldPass}
+                  onChange={e => setOldPass(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="mb-2">
+                <label className="form-label">New Password</label>
+                <input
+                  type="password"
+                  className="form-control"
+                  value={newPass}
+                  onChange={e => setNewPass(e.target.value)}
+                  required
+                />
+              </div>
+              <button type="submit" className="btn btn-primary btn-sm">
+                Update Password
+              </button>
+            </form>
+            <div className="form-check form-switch mb-3">
+              <input
+                className="form-check-input"
+                type="checkbox"
+                id="snoozeToggle"
+                checked={user.snoozed}
+                onChange={async () => {
+                  const all = await getUsers();
+                  const idx = all.findIndex(u => u.email === user.email);
+                  all[idx].snoozed = !all[idx].snoozed;
+                  await saveUsers(all);
+                  localStorage.setItem('currentUser', JSON.stringify(all[idx]));
+                  setUser(all[idx]);
+                }}
+              />
+              <label className="form-check-label" htmlFor="snoozeToggle">
+                Snooze account
+              </label>
+            </div>
+            <button
+              type="button"
+              className="btn btn-danger btn-sm"
+              onClick={async () => {
+                if (!window.confirm('Delete your account?')) return;
+                const all = await getUsers();
+                const remaining = all.filter(u => u.email !== user.email);
+                await saveUsers(remaining);
+                const p = await getPosts();
+                p.forEach(post => {
+                  post.applicants = post.applicants.filter(a => a !== user.email);
+                  delete post.statuses[user.email];
+                });
+                await savePosts(p);
+                localStorage.removeItem('currentUser');
+                navigate('/');
+              }}
+            >
+              Delete Account
+            </button>
           </div>
         )}
 

--- a/myapp/src/components/Forgot.tsx
+++ b/myapp/src/components/Forgot.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { getUsers, saveUsers, hashString } from '../utils';
+
+export default function Forgot() {
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [newPass, setNewPass] = useState('');
+  const [step, setStep] = useState(1);
+  const navigate = useNavigate();
+
+  const request = async () => {
+    const users = await getUsers();
+    const idx = users.findIndex(u => u.email === email);
+    if (idx === -1) {
+      alert('Email not found');
+      return;
+    }
+    const c = Math.random().toString(36).slice(2, 8);
+    users[idx].resetCode = c;
+    await saveUsers(users);
+    alert('Your reset code: ' + c);
+    setStep(2);
+  };
+
+  const reset = async () => {
+    const users = await getUsers();
+    const idx = users.findIndex(u => u.email === email && u.resetCode === code);
+    if (idx === -1) {
+      alert('Invalid code');
+      return;
+    }
+    users[idx].password = await hashString(newPass);
+    users[idx].resetCode = '';
+    await saveUsers(users);
+    alert('Password updated. You can now login.');
+    navigate('/login');
+  };
+
+  return (
+    <div className="container my-5" style={{ maxWidth: '420px' }}>
+      <div className="card shadow-sm">
+        <div className="card-body">
+          <h2 className="card-title mb-3">Forgot Password</h2>
+          {step === 1 && (
+            <>
+              <div className="mb-3">
+                <label className="form-label">Email</label>
+                <input
+                  type="email"
+                  className="form-control"
+                  value={email}
+                  onChange={e => setEmail(e.target.value)}
+                />
+              </div>
+              <button type="button" className="btn btn-primary" onClick={request}>
+                Request Reset
+              </button>
+            </>
+          )}
+          {step === 2 && (
+            <>
+              <div className="mb-3">
+                <label className="form-label">Reset Code</label>
+                <input
+                  className="form-control"
+                  value={code}
+                  onChange={e => setCode(e.target.value)}
+                />
+              </div>
+              <div className="mb-3">
+                <label className="form-label">New Password</label>
+                <input
+                  type="password"
+                  className="form-control"
+                  value={newPass}
+                  onChange={e => setNewPass(e.target.value)}
+                />
+              </div>
+              <button type="button" className="btn btn-primary" onClick={reset}>
+                Reset Password
+              </button>
+            </>
+          )}
+          <p className="mt-3 mb-0">
+            <Link to="/login">Back to login</Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/myapp/src/components/Interview.tsx
+++ b/myapp/src/components/Interview.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Nav from './Nav';
+
+export default function Interview() {
+  const navigate = useNavigate();
+  const localVideo = useRef(null as any);
+
+  useEffect(() => {
+    const u = localStorage.getItem('currentUser');
+    if (!u) return navigate('/login');
+    navigator.mediaDevices
+      .getUserMedia({ video: true, audio: true })
+      .then(stream => {
+        if (localVideo.current) {
+          localVideo.current.srcObject = stream;
+        }
+      })
+      .catch(() => {});
+  }, [navigate]);
+
+  return (
+    <div>
+      <Nav />
+      <div className="container my-4" style={{ maxWidth: '600px' }}>
+        <h2>Video Interview</h2>
+        <video ref={localVideo} autoPlay playsInline style={{ width: '100%', maxHeight: '400px' }} />
+        <p className="mt-3">This demo only shows your camera feed.</p>
+      </div>
+    </div>
+  );
+}

--- a/myapp/src/components/Jobs.tsx
+++ b/myapp/src/components/Jobs.tsx
@@ -183,6 +183,12 @@ export default function Jobs() {
                         <option value="interview">interview</option>
                         <option value="offer">offer</option>
                       </select>
+                  <Link
+                    to="/interview"
+                    className="btn btn-sm btn-outline-primary mt-1 ms-2"
+                  >
+                    Start Interview
+                  </Link>
                     </li>
                   ))}
                 </ul>

--- a/myapp/src/components/Jobs.tsx
+++ b/myapp/src/components/Jobs.tsx
@@ -13,7 +13,7 @@ export default function Jobs() {
   const [hidden, setHidden] = useState(new Set<number>());
   const [saved, setSaved] = useState(new Set<number>());
   const [viewed, setViewed] = useState(new Set<number>());
-  const [candidateQuery, setCandidateQuery] = useState('');
+  const [memberQuery, setMemberQuery] = useState('');
 
   useEffect(() => {
     const u = localStorage.getItem('currentUser');
@@ -56,7 +56,7 @@ export default function Jobs() {
   });
 
   const apply = async (id: number) => {
-    if (user.type === 'candidate' && (!user.skills || user.skills.length === 0)) {
+    if (!user.skills || user.skills.length === 0) {
       alert('Please complete your profile before applying.');
       return;
     }
@@ -115,13 +115,13 @@ export default function Jobs() {
 
   if (user.type === 'org') {
     const mine = posts.filter(p => p.authorEmail === user.email);
-    const candidates = users.filter(
+    const matchedMembers = users.filter(
       u =>
-        (u.type === 'member' || u.type === 'candidate') &&
-        candidateQuery &&
+        u.type === 'member' &&
+        memberQuery &&
         u.skills &&
         u.skills.some((s: string) =>
-          s.toLowerCase().includes(candidateQuery.toLowerCase())
+          s.toLowerCase().includes(memberQuery.toLowerCase())
         )
     );
     return (
@@ -196,15 +196,15 @@ export default function Jobs() {
             </div>
           ))}
           <div className="mt-4">
-            <h4>Search Candidates</h4>
-            <input
-              className="form-control mb-2"
-              placeholder="Search by skill"
-              value={candidateQuery}
-              onChange={e => setCandidateQuery(e.target.value)}
-            />
+          <h4>Search Members</h4>
+          <input
+            className="form-control mb-2"
+            placeholder="Search by skill"
+            value={memberQuery}
+            onChange={e => setMemberQuery(e.target.value)}
+          />
             <ul className="list-group">
-              {candidates.map(c => (
+              {matchedMembers.map(c => (
                 <li key={c.email} className="list-group-item d-flex justify-content-between align-items-center">
                   <span>
                     {c.email} - {(c.skills || []).join(', ')}
@@ -304,7 +304,7 @@ export default function Jobs() {
                   >
                     Hide
                   </button>
-                  {(user.type === 'member' || user.type === 'candidate') && (
+                  {user.type === 'member' && (
                     p.applicants.includes(user.email) ? (
                       <button
                         type="button"
@@ -324,11 +324,9 @@ export default function Jobs() {
                           e.stopPropagation();
                           apply(p.id);
                         }}
-                        disabled={
-                          user.type === 'candidate' && (!user.skills || user.skills.length === 0)
-                        }
+                        disabled={!user.skills || user.skills.length === 0}
                         title={
-                          user.type === 'candidate' && (!user.skills || user.skills.length === 0)
+                          !user.skills || user.skills.length === 0
                             ? 'Complete your profile to apply'
                             : undefined
                         }

--- a/myapp/src/components/Jobs.tsx
+++ b/myapp/src/components/Jobs.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import Nav from './Nav';
-import { getPosts, savePosts, getUsers } from '../utils';
+import { getPosts, savePosts, getUsers, saveUsers } from '../utils';
 
 export default function Jobs() {
   const navigate = useNavigate();
@@ -94,6 +94,17 @@ export default function Jobs() {
     setPosts(filtered);
   };
 
+  const requestProfile = async (email: string) => {
+    const all = await getUsers();
+    const idx = all.findIndex(u => u.email === email);
+    if (!all[idx].profileRequests) all[idx].profileRequests = [];
+    if (!all[idx].profileRequests.includes(user.email)) {
+      all[idx].profileRequests.push(user.email);
+      await saveUsers(all);
+      setUsers(all);
+    }
+  };
+
   const markViewed = (id: number) => {
     if (viewed.has(id)) return;
     const v = new Set(viewed);
@@ -137,9 +148,32 @@ export default function Jobs() {
                 <ul className="list-group mb-2">
                   {p.applicants.map(a => (
                     <li key={a} className="list-group-item">
-                      {(users.find(u => u.email === a)?.skills || []).join(', ') ||
+                  {(users.find(u => u.email === a)?.skills || []).join(', ') ||
                         'No skills'}
-                      <select
+                  {(() => {
+                    const cand = users.find(u => u.email === a);
+                    if (!cand) return null;
+                    return cand.profileShares && cand.profileShares.includes(user.email) ? (
+                      <Link
+                        to={`/profile/${cand.email}`}
+                        className="btn btn-sm btn-outline-info ms-2"
+                      >
+                        View Profile
+                      </Link>
+                    ) : (
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-info ms-2"
+                        onClick={() => requestProfile(cand.email)}
+                        disabled={cand.profileRequests && cand.profileRequests.includes(user.email)}
+                      >
+                        {cand.profileRequests && cand.profileRequests.includes(user.email)
+                          ? 'Requested'
+                          : 'Request Profile'}
+                      </button>
+                    );
+                  })()}
+                  <select
                         className="form-select form-select-sm mt-1"
                         value={p.statuses[a] || 'applied'}
                         onChange={e => updateStatus(p.id, a, e.target.value)}
@@ -165,8 +199,29 @@ export default function Jobs() {
             />
             <ul className="list-group">
               {candidates.map(c => (
-                <li key={c.email} className="list-group-item">
-                  {c.email} - {(c.skills || []).join(', ')}
+                <li key={c.email} className="list-group-item d-flex justify-content-between align-items-center">
+                  <span>
+                    {c.email} - {(c.skills || []).join(', ')}
+                  </span>
+                  {c.profileShares && c.profileShares.includes(user.email) ? (
+                    <Link
+                      to={`/profile/${c.email}`}
+                      className="btn btn-sm btn-outline-info"
+                    >
+                      View Profile
+                    </Link>
+                  ) : (
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-info"
+                      onClick={() => requestProfile(c.email)}
+                      disabled={c.profileRequests && c.profileRequests.includes(user.email)}
+                    >
+                      {c.profileRequests && c.profileRequests.includes(user.email)
+                        ? 'Requested'
+                        : 'Request Profile'}
+                    </button>
+                  )}
                 </li>
               ))}
             </ul>

--- a/myapp/src/components/Jobs.tsx
+++ b/myapp/src/components/Jobs.tsx
@@ -1,23 +1,28 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Nav from './Nav';
-import { getPosts, savePosts } from '../utils';
+import { getPosts, savePosts, getUsers } from '../utils';
 
 export default function Jobs() {
   const navigate = useNavigate();
   const [user, setUser] = useState(null as any);
   const [posts, setPosts] = useState([] as any[]);
+  const [users, setUsers] = useState([] as any[]);
   const [filter, setFilter] = useState('all');
   const [sort, setSort] = useState('recent');
   const [hidden, setHidden] = useState(new Set<number>());
   const [saved, setSaved] = useState(new Set<number>());
   const [viewed, setViewed] = useState(new Set<number>());
+  const [candidateQuery, setCandidateQuery] = useState('');
 
   useEffect(() => {
     const u = localStorage.getItem('currentUser');
     if (!u) return navigate('/login');
     setUser(JSON.parse(u));
-    getPosts().then(setPosts);
+    Promise.all([getPosts(), getUsers()]).then(([p, us]) => {
+      setPosts(p);
+      setUsers(us);
+    });
     setHidden(new Set(JSON.parse(localStorage.getItem('hiddenJobs') || '[]')));
     setSaved(new Set(JSON.parse(localStorage.getItem('savedJobs') || '[]')));
     setViewed(new Set(JSON.parse(localStorage.getItem('viewedJobs') || '[]')));
@@ -55,6 +60,7 @@ export default function Jobs() {
     const idx = all.findIndex(x => x.id === id);
     if (!all[idx].applicants.includes(user.email)) {
       all[idx].applicants.push(user.email);
+      all[idx].statuses[user.email] = 'applied';
       await savePosts(all);
       setPosts(all);
     }
@@ -64,8 +70,24 @@ export default function Jobs() {
     const all = await getPosts();
     const idx = all.findIndex(x => x.id === id);
     all[idx].applicants = all[idx].applicants.filter((a: string) => a !== user.email);
+    delete all[idx].statuses[user.email];
     await savePosts(all);
     setPosts(all);
+  };
+
+  const updateStatus = async (postId: number, email: string, status: string) => {
+    const all = await getPosts();
+    const idx = all.findIndex(x => x.id === postId);
+    all[idx].statuses[email] = status;
+    await savePosts(all);
+    setPosts(all);
+  };
+
+  const withdrawPost = async (postId: number) => {
+    const all = await getPosts();
+    const filtered = all.filter(p => p.id !== postId);
+    await savePosts(filtered);
+    setPosts(filtered);
   };
 
   const markViewed = (id: number) => {
@@ -75,6 +97,80 @@ export default function Jobs() {
     localStorage.setItem('viewedJobs', JSON.stringify(Array.from(v)));
     setViewed(v);
   };
+
+  if (user.type === 'org') {
+    const mine = posts.filter(p => p.authorEmail === user.email);
+    const candidates = users.filter(
+      u =>
+        u.type === 'member' &&
+        candidateQuery &&
+        u.skills &&
+        u.skills.some((s: string) =>
+          s.toLowerCase().includes(candidateQuery.toLowerCase())
+        )
+    );
+    return (
+      <div>
+        <Nav />
+        <div className="container my-4">
+          <h2>Your Job Posts</h2>
+          <a href="/create" className="btn btn-primary mb-3">
+            Post a Job
+          </a>
+          {mine.map(p => (
+            <div key={p.id} className="card mb-3">
+              <div className="card-body">
+                <h5 className="card-title">{p.title}</h5>
+                <p>{p.description}</p>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-danger mb-3"
+                  onClick={() => withdrawPost(p.id)}
+                >
+                  Withdraw Post
+                </button>
+                <h6>Applicants</h6>
+                <ul className="list-group mb-2">
+                  {p.applicants.map(a => (
+                    <li key={a} className="list-group-item">
+                      {(users.find(u => u.email === a)?.skills || []).join(', ') ||
+                        'No skills'}
+                      <select
+                        className="form-select form-select-sm mt-1"
+                        value={p.statuses[a] || 'applied'}
+                        onChange={e => updateStatus(p.id, a, e.target.value)}
+                      >
+                        <option value="applied">applied</option>
+                        <option value="review">review</option>
+                        <option value="interview">interview</option>
+                        <option value="offer">offer</option>
+                      </select>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ))}
+          <div className="mt-4">
+            <h4>Search Candidates</h4>
+            <input
+              className="form-control mb-2"
+              placeholder="Search by skill"
+              value={candidateQuery}
+              onChange={e => setCandidateQuery(e.target.value)}
+            />
+            <ul className="list-group">
+              {candidates.map(c => (
+                <li key={c.email} className="list-group-item">
+                  {c.email} - {(c.skills || []).join(', ')}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div>
@@ -115,8 +211,12 @@ export default function Jobs() {
               <div className="d-flex justify-content-between">
                 <div>
                   <strong>{p.title}</strong> ({p.postType}) by {p.authorEmail}
-                  {viewed.has(p.id) && <span className="badge bg-secondary ms-2">viewed</span>}
-                  {saved.has(p.id) && <span className="badge bg-info text-dark ms-2">saved</span>}
+                  {viewed.has(p.id) && (
+                    <span className="badge bg-secondary ms-2">viewed</span>
+                  )}
+                  {saved.has(p.id) && (
+                    <span className="badge bg-info text-dark ms-2">saved</span>
+                  )}
                 </div>
                 <div>
                   <button

--- a/myapp/src/components/Jobs.tsx
+++ b/myapp/src/components/Jobs.tsx
@@ -114,7 +114,7 @@ export default function Jobs() {
             >
               <div className="d-flex justify-content-between">
                 <div>
-                  <strong>{p.title}</strong> ({p.postType}) by {p.orgEmail}
+                  <strong>{p.title}</strong> ({p.postType}) by {p.authorEmail}
                   {viewed.has(p.id) && <span className="badge bg-secondary ms-2">viewed</span>}
                   {saved.has(p.id) && <span className="badge bg-info text-dark ms-2">saved</span>}
                 </div>

--- a/myapp/src/components/Jobs.tsx
+++ b/myapp/src/components/Jobs.tsx
@@ -56,6 +56,10 @@ export default function Jobs() {
   });
 
   const apply = async (id: number) => {
+    if (user.type === 'candidate' && (!user.skills || user.skills.length === 0)) {
+      alert('Please complete your profile before applying.');
+      return;
+    }
     const all = await getPosts();
     const idx = all.findIndex(x => x.id === id);
     if (!all[idx].applicants.includes(user.email)) {
@@ -102,7 +106,7 @@ export default function Jobs() {
     const mine = posts.filter(p => p.authorEmail === user.email);
     const candidates = users.filter(
       u =>
-        u.type === 'member' &&
+        (u.type === 'member' || u.type === 'candidate') &&
         candidateQuery &&
         u.skills &&
         u.skills.some((s: string) =>
@@ -239,7 +243,7 @@ export default function Jobs() {
                   >
                     Hide
                   </button>
-                  {user.type === 'member' && (
+                  {(user.type === 'member' || user.type === 'candidate') && (
                     p.applicants.includes(user.email) ? (
                       <button
                         type="button"
@@ -259,6 +263,14 @@ export default function Jobs() {
                           e.stopPropagation();
                           apply(p.id);
                         }}
+                        disabled={
+                          user.type === 'candidate' && (!user.skills || user.skills.length === 0)
+                        }
+                        title={
+                          user.type === 'candidate' && (!user.skills || user.skills.length === 0)
+                            ? 'Complete your profile to apply'
+                            : undefined
+                        }
                       >
                         Apply
                       </button>

--- a/myapp/src/components/Login.tsx
+++ b/myapp/src/components/Login.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import { getUsers } from '../utils';
+import { getUsers, hashString } from '../utils';
 
 export default function Login() {
   const [email, setEmail] = useState('');
@@ -10,7 +10,8 @@ export default function Login() {
   const handleSubmit = async (e: any) => {
     e.preventDefault();
     const users = await getUsers();
-    const found = users.find((u: any) => u.email === email && u.password === password);
+    const hashed = await hashString(password);
+    const found = users.find((u: any) => u.email === email && u.password === hashed);
     if (found) {
       if (!found.verified) {
         alert('Please verify your account first.');
@@ -49,6 +50,9 @@ export default function Login() {
                 onChange={e => setPassword(e.target.value)}
                 required
               />
+              <div className="form-text">
+                <Link to="/forgot">Forgot password?</Link>
+              </div>
             </div>
             <button type="submit" className="btn btn-primary">
               Login

--- a/myapp/src/components/Login.tsx
+++ b/myapp/src/components/Login.tsx
@@ -9,19 +9,25 @@ export default function Login() {
 
   const handleSubmit = async (e: any) => {
     e.preventDefault();
-    const users = await getUsers();
-    const hashed = await hashString(password);
-    const found = users.find((u: any) => u.email === email && u.password === hashed);
-    if (found) {
-      if (!found.verified) {
-        alert('Please verify your account first.');
-        navigate(`/verify?email=${encodeURIComponent(email)}`);
-        return;
+    try {
+      const users = await getUsers();
+      const hashed = await hashString(password);
+      const found = users.find(
+        (u: any) => u.email === email && u.password === hashed
+      );
+      if (found) {
+        if (!found.verified) {
+          alert('Please verify your account first.');
+          navigate(`/verify?email=${encodeURIComponent(email)}`);
+          return;
+        }
+        localStorage.setItem('currentUser', JSON.stringify(found));
+        navigate('/dashboard');
+      } else {
+        alert('Invalid credentials');
       }
-      localStorage.setItem('currentUser', JSON.stringify(found));
-      navigate('/dashboard');
-    } else {
-      alert('Invalid credentials');
+    } catch {
+      alert('Unable to connect to the database server.');
     }
   };
 

--- a/myapp/src/components/Nav.tsx
+++ b/myapp/src/components/Nav.tsx
@@ -5,6 +5,9 @@ export default function Nav() {
     localStorage.removeItem('currentUser');
   };
 
+  const current = localStorage.getItem('currentUser');
+  const me = current ? JSON.parse(current) : null;
+
   return (
     <nav className="navbar navbar-expand-lg navbar-light bg-light">
       <div className="container">
@@ -46,6 +49,23 @@ export default function Nav() {
                 Search
               </Link>
             </li>
+            <li className="nav-item">
+              <Link className="nav-link" to="/calendar">
+                Calendar
+              </Link>
+            </li>
+            <li className="nav-item">
+              <Link className="nav-link" to="/notes">
+                Notes
+              </Link>
+            </li>
+            {me && me.type === 'org' && (
+              <li className="nav-item">
+                <Link className="nav-link" to="/people-map">
+                  People Map
+                </Link>
+              </li>
+            )}
           </ul>
           <Link
             to="/login"

--- a/myapp/src/components/Notes.tsx
+++ b/myapp/src/components/Notes.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Nav from './Nav';
+import { getUsers, saveUsers } from '../utils';
+import { Note } from '../types';
+
+export default function Notes() {
+  const navigate = useNavigate();
+  const [user, setUser] = useState(null as any);
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    const u = localStorage.getItem('currentUser');
+    if (!u) return navigate('/login');
+    setUser(JSON.parse(u));
+  }, [navigate]);
+
+  if (!user) return null;
+
+  const addNote = async () => {
+    if (!text) return;
+    const all = await getUsers();
+    const idx = all.findIndex(u => u.email === user.email);
+    const note: Note = { id: Date.now(), text, timestamp: Date.now() };
+    if (!all[idx].notes) all[idx].notes = [];
+    all[idx].notes.push(note);
+    await saveUsers(all);
+    localStorage.setItem('currentUser', JSON.stringify(all[idx]));
+    setUser(all[idx]);
+    setText('');
+  };
+
+  const deleteNote = async (id: number) => {
+    const all = await getUsers();
+    const idx = all.findIndex(u => u.email === user.email);
+    all[idx].notes = all[idx].notes.filter((n: Note) => n.id !== id);
+    await saveUsers(all);
+    localStorage.setItem('currentUser', JSON.stringify(all[idx]));
+    setUser(all[idx]);
+  };
+
+  return (
+    <div>
+      <Nav />
+      <div className="container my-4" style={{ maxWidth: '600px' }}>
+        <h2>Notepad</h2>
+        <form
+          className="mb-3"
+          onSubmit={e => {
+            e.preventDefault();
+            addNote();
+          }}
+        >
+          <textarea
+            className="form-control mb-2"
+            value={text}
+            onChange={e => setText(e.target.value)}
+          />
+          <button type="submit" className="btn btn-primary">
+            Add Note
+          </button>
+        </form>
+        <ul className="list-group">
+          {user.notes.map((n: Note) => (
+            <li key={n.id} className="list-group-item d-flex justify-content-between align-items-center">
+              <span>{n.text}</span>
+              <button
+                type="button"
+                className="btn btn-sm btn-danger"
+                onClick={() => deleteNote(n.id)}
+              >
+                Delete
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/myapp/src/components/PeopleMap.tsx
+++ b/myapp/src/components/PeopleMap.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Nav from './Nav';
+import { getUsers, saveUsers } from '../utils';
+import { PeopleNeed } from '../types';
+
+export default function PeopleMap() {
+  const navigate = useNavigate();
+  const [user, setUser] = useState(null as any);
+  const [role, setRole] = useState('');
+  const [count, setCount] = useState(1);
+
+  useEffect(() => {
+    const u = localStorage.getItem('currentUser');
+    if (!u) return navigate('/login');
+    const me = JSON.parse(u);
+    if (me.type !== 'org') return navigate('/dashboard');
+    setUser(me);
+  }, [navigate]);
+
+  if (!user) return null;
+
+  const addNeed = async () => {
+    if (!role) return;
+    const all = await getUsers();
+    const idx = all.findIndex(u => u.email === user.email);
+    const pn: PeopleNeed = { role, count };
+    if (!all[idx].peopleMap) all[idx].peopleMap = [];
+    all[idx].peopleMap.push(pn);
+    await saveUsers(all);
+    localStorage.setItem('currentUser', JSON.stringify(all[idx]));
+    setUser(all[idx]);
+    setRole('');
+    setCount(1);
+  };
+
+  const removeNeed = async (i: number) => {
+    const all = await getUsers();
+    const idx = all.findIndex(u => u.email === user.email);
+    all[idx].peopleMap.splice(i, 1);
+    await saveUsers(all);
+    localStorage.setItem('currentUser', JSON.stringify(all[idx]));
+    setUser(all[idx]);
+  };
+
+  return (
+    <div>
+      <Nav />
+      <div className="container my-4" style={{ maxWidth: '600px' }}>
+        <h2>People Map</h2>
+        <form
+          className="mb-3"
+          onSubmit={e => {
+            e.preventDefault();
+            addNeed();
+          }}
+        >
+          <input
+            className="form-control mb-2"
+            placeholder="Role"
+            value={role}
+            onChange={e => setRole(e.target.value)}
+          />
+          <input
+            type="number"
+            className="form-control mb-2"
+            value={count}
+            min={1}
+            onChange={e => setCount(parseInt(e.target.value, 10))}
+          />
+          <button type="submit" className="btn btn-primary">
+            Add Need
+          </button>
+        </form>
+        <ul className="list-group">
+          {(user.peopleMap || []).map((p: PeopleNeed, i: number) => (
+            <li key={i} className="list-group-item d-flex justify-content-between align-items-center">
+              <span>
+                {p.role} - {p.count}
+              </span>
+              <button type="button" className="btn btn-sm btn-danger" onClick={() => removeNeed(i)}>
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/myapp/src/components/Profile.tsx
+++ b/myapp/src/components/Profile.tsx
@@ -62,6 +62,18 @@ export default function Profile() {
             </ul>
           </div>
         )}
+        {user.recommendations && user.recommendations.length > 0 && (
+          <div className="mt-3">
+            <h5>Recommendations</h5>
+            <ul className="list-group">
+              {user.recommendations.map((r: any, i: number) => (
+                <li key={i} className="list-group-item">
+                  <strong>{r.from}</strong>: {r.text}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/myapp/src/components/Profile.tsx
+++ b/myapp/src/components/Profile.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import Nav from './Nav';
+import { getUsers } from '../utils';
+
+export default function Profile() {
+  const { email } = useParams();
+  const navigate = useNavigate();
+  const [viewer, setViewer] = useState(null as any);
+  const [user, setUser] = useState(null as any);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('currentUser');
+    if (!stored) return navigate('/login');
+    const me = JSON.parse(stored);
+    setViewer(me);
+    getUsers().then(all => {
+      const found = all.find((u: any) => u.email === email);
+      if (!found) return navigate('/community');
+      setUser(found);
+    });
+  }, [email, navigate]);
+
+  if (!viewer || !user) return null;
+
+  const allowed =
+    viewer.email === user.email || (user.profileShares || []).includes(viewer.email);
+
+  if (!allowed) {
+    return (
+      <div>
+        <Nav />
+        <div className="container my-4" style={{ maxWidth: '600px' }}>
+          <h4>Profile access not granted.</h4>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Nav />
+      <div className="container my-4" style={{ maxWidth: '600px' }}>
+        <h2>{user.email} Profile</h2>
+        <h5>Skills</h5>
+        <p>{(user.skills || []).join(', ') || 'No skills listed'}</p>
+        {user.bio && (
+          <div className="mb-2">
+            <h5>Bio</h5>
+            <p>{user.bio}</p>
+          </div>
+        )}
+        {user.docs && user.docs.length > 0 && (
+          <div>
+            <h5>Documents</h5>
+            <ul className="list-group">
+              {user.docs.map((d: string, i: number) => (
+                <li key={i} className="list-group-item">
+                  {d}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/myapp/src/components/Register.tsx
+++ b/myapp/src/components/Register.tsx
@@ -34,12 +34,17 @@ export default function Register() {
       recommendations: [],
       resume: '',
       bio: '',
+      events: [],
+      notes: [],
     };
     if (type === 'member' || type === 'candidate') {
       newUser.skills = skills
         .split(',')
         .map((s: string) => s.trim())
         .filter((s: string) => s);
+    }
+    if (type === 'org') {
+      newUser.peopleMap = [];
     }
     users.push(newUser);
     await saveUsers(users);

--- a/myapp/src/components/Register.tsx
+++ b/myapp/src/components/Register.tsx
@@ -28,6 +28,11 @@ export default function Register() {
       verified: false,
       followers: [],
       groups: [],
+      docs: [],
+      profileRequests: [],
+      profileShares: [],
+      resume: '',
+      bio: '',
     };
     if (type === 'member' || type === 'candidate') {
       newUser.skills = skills

--- a/myapp/src/components/Register.tsx
+++ b/myapp/src/components/Register.tsx
@@ -6,13 +6,36 @@ export default function Register() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [phone, setPhone] = useState('');
+  const [contactName, setContactName] = useState('');
   const [type, setType] = useState('member');
+  const [skills, setSkills] = useState('');
   const navigate = useNavigate();
 
   const handleSubmit = async (e: any) => {
     e.preventDefault();
+    const generic = ['info@', 'contact@', 'noreply@'];
+    if (type === 'org' && generic.some(g => email.startsWith(g))) {
+      alert('Please use a real contact email for your organization.');
+      return;
+    }
     const users = await getUsers();
-    users.push({ email, password, phone, type, verified: false, followers: [], groups: [] });
+    const newUser: any = {
+      email,
+      password,
+      phone,
+      contactName,
+      type,
+      verified: false,
+      followers: [],
+      groups: [],
+    };
+    if (type === 'member') {
+      newUser.skills = skills
+        .split(',')
+        .map((s: string) => s.trim())
+        .filter((s: string) => s);
+    }
+    users.push(newUser);
     await saveUsers(users);
     alert('Verification link sent. Please verify to activate your account.');
     navigate(`/verify?email=${encodeURIComponent(email)}`);
@@ -45,6 +68,15 @@ export default function Register() {
           />
         </div>
         <div className="mb-3">
+          <label className="form-label">Contact Name</label>
+          <input
+            className="form-control"
+            value={contactName}
+            onChange={e => setContactName(e.target.value)}
+            required
+          />
+        </div>
+        <div className="mb-3">
           <label className="form-label">Password</label>
           <input
             type="password"
@@ -61,6 +93,16 @@ export default function Register() {
             <option value="org">Organization</option>
           </select>
         </div>
+        {type === 'member' && (
+          <div className="mb-3">
+            <label className="form-label">Skills (comma separated)</label>
+            <input
+              className="form-control"
+              value={skills}
+              onChange={e => setSkills(e.target.value)}
+            />
+          </div>
+        )}
             <button type="submit" className="btn btn-primary">
               Register
             </button>

--- a/myapp/src/components/Register.tsx
+++ b/myapp/src/components/Register.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import { getUsers, saveUsers } from '../utils';
+import { getUsers, saveUsers, hashString } from '../utils';
 
 export default function Register() {
   const [email, setEmail] = useState('');
@@ -19,9 +19,10 @@ export default function Register() {
       return;
     }
     const users = await getUsers();
+    const hashed = await hashString(password);
     const newUser: any = {
       email,
-      password,
+      password: hashed,
       phone,
       contactName,
       type,
@@ -36,6 +37,9 @@ export default function Register() {
       bio: '',
       events: [],
       notes: [],
+      snoozed: false,
+      blocked: [],
+      resetCode: '',
     };
     if (type === 'member' || type === 'candidate') {
       newUser.skills = skills

--- a/myapp/src/components/Register.tsx
+++ b/myapp/src/components/Register.tsx
@@ -29,7 +29,7 @@ export default function Register() {
       followers: [],
       groups: [],
     };
-    if (type === 'member') {
+    if (type === 'member' || type === 'candidate') {
       newUser.skills = skills
         .split(',')
         .map((s: string) => s.trim())
@@ -88,8 +88,13 @@ export default function Register() {
         </div>
         <div className="mb-3">
           <label className="form-label">User Type</label>
-          <select className="form-select" value={type} onChange={e => setType(e.target.value)}>
+          <select
+            className="form-select"
+            value={type}
+            onChange={e => setType(e.target.value)}
+          >
             <option value="member">Community Member</option>
+            <option value="candidate">Candidate</option>
             <option value="org">Organization</option>
           </select>
         </div>

--- a/myapp/src/components/Register.tsx
+++ b/myapp/src/components/Register.tsx
@@ -41,7 +41,7 @@ export default function Register() {
       blocked: [],
       resetCode: '',
     };
-    if (type === 'member' || type === 'candidate') {
+    if (type === 'member') {
       newUser.skills = skills
         .split(',')
         .map((s: string) => s.trim())
@@ -109,7 +109,6 @@ export default function Register() {
             onChange={e => setType(e.target.value)}
           >
             <option value="member">Community Member</option>
-            <option value="candidate">Candidate</option>
             <option value="org">Organization</option>
           </select>
         </div>

--- a/myapp/src/components/Register.tsx
+++ b/myapp/src/components/Register.tsx
@@ -31,6 +31,7 @@ export default function Register() {
       docs: [],
       profileRequests: [],
       profileShares: [],
+      recommendations: [],
       resume: '',
       bio: '',
     };

--- a/myapp/src/components/Search.tsx
+++ b/myapp/src/components/Search.tsx
@@ -19,7 +19,7 @@ export default function Search() {
         p =>
           p.title.toLowerCase().includes(q) ||
           p.description.toLowerCase().includes(q) ||
-          p.orgEmail.toLowerCase().includes(q) ||
+          p.authorEmail.toLowerCase().includes(q) ||
           p.tags.some(t => t.toLowerCase().includes(q))
       );
       setRecommended(matches.filter(p => !p.applicants.includes(me.email)));
@@ -43,7 +43,7 @@ export default function Search() {
           <ul className="list-group mb-3">
             {recommended.map(r => (
               <li key={r.id} className="list-group-item">
-                <strong>{r.title}</strong> ({r.postType}) by {r.orgEmail}
+                <strong>{r.title}</strong> ({r.postType}) by {r.authorEmail}
                 <p>{r.description}</p>
               </li>
             ))}
@@ -53,7 +53,7 @@ export default function Search() {
           <ul className="list-group mb-3">
             {applied.map(r => (
               <li key={r.id} className="list-group-item">
-                <strong>{r.title}</strong> ({r.postType}) by {r.orgEmail}
+                <strong>{r.title}</strong> ({r.postType}) by {r.authorEmail}
                 <p>{r.description}</p>
               </li>
             ))}
@@ -63,7 +63,7 @@ export default function Search() {
           <ul className="list-group list-group-flush">
             {insights.map(r => (
               <li key={r.id} className="list-group-item">
-                <strong>{r.title}</strong> ({r.postType}) by {r.orgEmail}
+                <strong>{r.title}</strong> ({r.postType}) by {r.authorEmail}
                 <p>{r.description}</p>
               </li>
             ))}

--- a/myapp/src/components/Search.tsx
+++ b/myapp/src/components/Search.tsx
@@ -1,16 +1,32 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { getPosts } from '../utils';
 
 export default function Search() {
+  const navigate = useNavigate();
   const [query, setQuery] = useState('');
-  const [results, setResults] = useState([] as any[]);
+  const [recommended, setRecommended] = useState([] as any[]);
+  const [applied, setApplied] = useState([] as any[]);
+  const [insights, setInsights] = useState([] as any[]);
 
   useEffect(() => {
+    const u = localStorage.getItem('currentUser');
+    if (!u) return navigate('/login');
+    const me = JSON.parse(u);
     getPosts().then(posts => {
       const q = query.toLowerCase();
-      setResults(posts.filter(p => p.title.toLowerCase().includes(q) || p.orgEmail.toLowerCase().includes(q)));
+      const matches = posts.filter(
+        p =>
+          p.title.toLowerCase().includes(q) ||
+          p.description.toLowerCase().includes(q) ||
+          p.orgEmail.toLowerCase().includes(q) ||
+          p.tags.some(t => t.toLowerCase().includes(q))
+      );
+      setRecommended(matches.filter(p => !p.applicants.includes(me.email)));
+      setApplied(matches.filter(p => p.applicants.includes(me.email)));
+      setInsights(matches);
     });
-  }, [query]);
+  }, [query, navigate]);
 
   return (
     <div className="container my-4" style={{ maxWidth: '500px' }}>
@@ -23,8 +39,29 @@ export default function Search() {
             value={query}
             onChange={e => setQuery(e.target.value)}
           />
+          <h4>Recommended Jobs</h4>
+          <ul className="list-group mb-3">
+            {recommended.map(r => (
+              <li key={r.id} className="list-group-item">
+                <strong>{r.title}</strong> ({r.postType}) by {r.orgEmail}
+                <p>{r.description}</p>
+              </li>
+            ))}
+          </ul>
+
+          <h4>Recently Applied</h4>
+          <ul className="list-group mb-3">
+            {applied.map(r => (
+              <li key={r.id} className="list-group-item">
+                <strong>{r.title}</strong> ({r.postType}) by {r.orgEmail}
+                <p>{r.description}</p>
+              </li>
+            ))}
+          </ul>
+
+          <h4>Relevant Posts</h4>
           <ul className="list-group list-group-flush">
-            {results.map(r => (
+            {insights.map(r => (
               <li key={r.id} className="list-group-item">
                 <strong>{r.title}</strong> ({r.postType}) by {r.orgEmail}
                 <p>{r.description}</p>

--- a/myapp/src/components/Verify.tsx
+++ b/myapp/src/components/Verify.tsx
@@ -12,8 +12,18 @@ export default function Verify() {
     if (idx !== -1) {
       users[idx].verified = true;
       await saveUsers(users);
+      const current = localStorage.getItem('currentUser');
+      if (current) {
+        const parsed = JSON.parse(current);
+        if (parsed.email === email) {
+          parsed.verified = true;
+          localStorage.setItem('currentUser', JSON.stringify(parsed));
+        }
+      }
       alert('Account verified! You can now login.');
       navigate('/login');
+    } else {
+      alert('User not found.');
     }
   };
 

--- a/myapp/src/types.ts
+++ b/myapp/src/types.ts
@@ -3,7 +3,7 @@ export interface User {
   password: string;
   phone: string;
   contactName: string;
-  type: 'member' | 'candidate' | 'org' | 'admin';
+  type: 'member' | 'org' | 'admin';
   verified: boolean;
   followers: string[];
   groups: number[];

--- a/myapp/src/types.ts
+++ b/myapp/src/types.ts
@@ -8,6 +8,11 @@ export interface User {
   followers: string[];
   groups: number[];
   skills?: string[];
+  resume?: string;
+  bio?: string;
+  docs: string[];
+  profileRequests: string[];
+  profileShares: string[];
 }
 
 export interface Comment {

--- a/myapp/src/types.ts
+++ b/myapp/src/types.ts
@@ -3,7 +3,7 @@ export interface User {
   password: string;
   phone: string;
   contactName: string;
-  type: 'member' | 'org' | 'admin';
+  type: 'member' | 'candidate' | 'org' | 'admin';
   verified: boolean;
   followers: string[];
   groups: number[];

--- a/myapp/src/types.ts
+++ b/myapp/src/types.ts
@@ -8,14 +8,22 @@ export interface User {
   groups: number[];
 }
 
+export interface Comment {
+  userEmail: string;
+  text: string;
+  timestamp: number;
+}
+
 export interface Post {
   id: number;
-  orgEmail: string;
+  authorEmail: string;
+  authorType: 'member' | 'org';
   title: string;
   description: string;
   postType: 'job' | 'internship' | 'volunteering' | 'project';
   tags: string[];
   applicants: string[];
+  comments: Comment[];
 }
 
 export interface Group {

--- a/myapp/src/types.ts
+++ b/myapp/src/types.ts
@@ -17,6 +17,9 @@ export interface User {
   events: CalendarEvent[];
   notes: Note[];
   peopleMap?: PeopleNeed[];
+  snoozed?: boolean;
+  blocked?: string[];
+  resetCode?: string;
 }
 
 export interface Recommendation {

--- a/myapp/src/types.ts
+++ b/myapp/src/types.ts
@@ -2,10 +2,12 @@ export interface User {
   email: string;
   password: string;
   phone: string;
+  contactName: string;
   type: 'member' | 'org' | 'admin';
   verified: boolean;
   followers: string[];
   groups: number[];
+  skills?: string[];
 }
 
 export interface Comment {
@@ -23,6 +25,7 @@ export interface Post {
   postType: 'job' | 'internship' | 'volunteering' | 'project';
   tags: string[];
   applicants: string[];
+  statuses: Record<string, string>;
   comments: Comment[];
 }
 

--- a/myapp/src/types.ts
+++ b/myapp/src/types.ts
@@ -14,6 +14,9 @@ export interface User {
   profileRequests: string[];
   profileShares: string[];
   recommendations?: Recommendation[];
+  events: CalendarEvent[];
+  notes: Note[];
+  peopleMap?: PeopleNeed[];
 }
 
 export interface Recommendation {
@@ -52,4 +55,22 @@ export interface Message {
   to: string;
   text: string;
   timestamp: number;
+}
+
+export interface CalendarEvent {
+  id: number;
+  title: string;
+  date: string;
+  alert: boolean;
+}
+
+export interface Note {
+  id: number;
+  text: string;
+  timestamp: number;
+}
+
+export interface PeopleNeed {
+  role: string;
+  count: number;
 }

--- a/myapp/src/types.ts
+++ b/myapp/src/types.ts
@@ -13,6 +13,13 @@ export interface User {
   docs: string[];
   profileRequests: string[];
   profileShares: string[];
+  recommendations?: Recommendation[];
+}
+
+export interface Recommendation {
+  from: string;
+  text: string;
+  timestamp: number;
 }
 
 export interface Comment {

--- a/myapp/src/utils.ts
+++ b/myapp/src/utils.ts
@@ -11,16 +11,27 @@ export async function hashString(str: string): Promise<string> {
 const API = 'http://localhost:3001';
 
 async function fetchJSON(key: string): Promise<any> {
-  const res = await fetch(`${API}/${key}`);
-  return res.json();
+  try {
+    const res = await fetch(`${API}/${key}`);
+    if (!res.ok) throw new Error('Server response not OK');
+    return await res.json();
+  } catch (err) {
+    console.error('Fetch failed for', key, err);
+    throw err;
+  }
 }
 
 async function postJSON(key: string, data: any): Promise<void> {
-  await fetch(`${API}/${key}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
+  try {
+    await fetch(`${API}/${key}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+  } catch (err) {
+    console.error('Post failed for', key, err);
+    throw err;
+  }
 }
 
 export async function getUsers(): Promise<User[]> {

--- a/myapp/src/utils.ts
+++ b/myapp/src/utils.ts
@@ -1,5 +1,13 @@
 import { User, Post, Group, Message } from './types';
 
+export async function hashString(str: string): Promise<string> {
+  const buf = new TextEncoder().encode(str);
+  const hash = await crypto.subtle.digest('SHA-256', buf);
+  return Array.from(new Uint8Array(hash))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
 const API = 'http://localhost:3001';
 
 async function fetchJSON(key: string): Promise<any> {


### PR DESCRIPTION
## Summary
- show all groups in the Community page
- allow joining groups and messaging them
- enable basic group chat by recognizing `group-*` targets

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f579b8b78832f8dfe7d9beae68112